### PR TITLE
#008 役割の付与・削除機能(2024.1.20)

### DIFF
--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -11,6 +11,7 @@ use Illuminate\View\View;
 use App\Models\User;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Validation\Rule;
+use App\Models\Role;
 
 class ProfileController extends Controller
 {
@@ -81,9 +82,12 @@ class ProfileController extends Controller
 
     public function adedit(User $user){
         $admin = true;
+        $roles = Role::all();
+
         return view('profile.edit',[
             'user' => $user,
             'admin' => $admin,
+            'roles' => $roles,
         ]);
     }
 

--- a/app/Http/Controllers/RoleController.php
+++ b/app/Http/Controllers/RoleController.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Models\User;
+use App\Models\Role;
+
+class RoleController extends Controller
+{
+  public function attach(Request $request,User $user) {
+    $roleId = request()->input('role');
+    $user->roles()->attach($roleId);
+    return back();
+  }
+
+  public function detach(Request $request,User $user) {
+    $roleId = request()->input('detach');
+    $user->roles()->detach($roleId);
+    return back();
+  }
+}

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -8,3 +8,9 @@
 .btnsetr{
 @apply mr-4 bg-red-700 font-bold text-base  text-center;
 }
+.btnroleb {
+@apply  inline-flex items-center px-2 py-1  text-blue-500 border border-blue-500 rounded-md font-bold text-base uppercase tracking-widest hover:bg-blue-200 focus:bg-blue-300 active:bg-blue-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 transition ease-in-out duration-150;
+}
+.btnroler {
+@apply  inline-flex items-center px-2 py-1  text-red-500 border border-red-500 rounded-md font-bold text-base uppercase tracking-widest hover:bg-red-200 focus:bg-red-300 active:bg-red-500 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 transition ease-in-out duration-150;
+}

--- a/resources/views/profile/edit.blade.php
+++ b/resources/views/profile/edit.blade.php
@@ -12,7 +12,14 @@
                     @include('profile.partials.update-profile-information-form')
                 </div>
             </div>
-
+            {{-- 追加部分 --}}
+            @if(isset($admin))
+            <div class="p-4 sm:p-8 bg-white shadow sm:rounded-lg">
+                <div class="max-w-xl">
+                    @include('profile.partials.role-user-form')
+                </div>
+            </div>
+            @endif
             <div class="p-4 sm:p-8 bg-white shadow sm:rounded-lg">
                 <div class="max-w-xl">
                     @include('profile.partials.update-password-form')

--- a/resources/views/profile/partials/role-user-form.blade.php
+++ b/resources/views/profile/partials/role-user-form.blade.php
@@ -1,0 +1,54 @@
+<div class="mt-5">
+    <h4 class="mb-3">役割付与・削除（アドミンユーザーにのみ表示）</h4>
+    <table class="text-left w-full border-collapse mt-8">
+        <tr class="bg-green-600 text-center">
+            <th>役割</th>
+            <th>付与</th>
+            <th>削除</th>
+        </tr>
+        @foreach ($roles as $role)
+        <tr class="bg-white text-center">
+            <td class="p-3">
+                {{$role->name}}
+            </td>
+            <td class="p-3">
+
+                <form method="post" action="{{route('role.attach', $user)}}">
+                    @csrf
+                    @method('patch')
+                    <input type="hidden" name="role" value="{{$role->id}}">
+                    <button class="btnroleb
+                    @if($user->roles->contains($role))
+                    bg-gray-300
+                    @endif
+                    "
+                    @if($user->roles->contains($role))
+                    disabled
+                    @endif
+                    >
+                    役割付与
+                    </button>
+                </form>
+            </td>
+            <td class="p-3">
+                <form method="post" action="{{route('role.detach', $user)}}">
+                    @csrf
+                    @method('patch')
+                    <input type="hidden" name="role" value="{{$role->id}}">
+                    <button class="btnroler
+                    @if(!$user->roles->contains($role))
+                    bg-gray-300
+                    @endif
+                    "
+                    @if(!$user->roles->contains($role))
+                    disabled
+                    @endif
+                    >
+                    役割削除
+                    </button>
+                </form>
+            </td>
+        </tr>
+        @endforeach
+   </table>
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -5,6 +5,7 @@ use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\PostController;
 use App\Http\Controllers\CommentController;
 use App\Http\Controllers\ContactController;
+use App\Http\Controllers\RoleController;
 /*
 |--------------------------------------------------------------------------
 | Web Routes
@@ -53,6 +54,8 @@ Route::middleware('verified')->group(function () {
         Route::get('/profile/index',[ProfileController::class,'index'])->name('profile.index');
         Route::get('/profile/adedit/{user}',[ProfileController::class,'adedit'])->name('profile.adedit');
         Route::patch('/profile/adupdate/{user}',[ProfileController::class,'adupdate'])->name('profile.adupdate');
+        Route::patch('roles/{user}/attach',[RoleController::class,'attach'])->name('role.attach'); //ユーザー役割の付与
+        Route::patch('roles/{user}/detach',[RokeController::class,'detach'])->name('role.detach'); //ユーザー役割の剥奪
     });
 
 


### PR DESCRIPTION
#260 posts（投稿）テーブルのマイグレーションとシーダー作成

https://github.com/yukihiroLaravel/joint_develop/pull/297

## issue
- Close #008
## 概要
- #0088 役割の付与・削除機能(2024.1.20)
## 動作確認手順
-管理者がログインしユーザー一覧ページを開き、任意のユーザーの編集ボタンをクリック
- ユーザーのアカウント画面に役割の付与・削除テーブルがある事を確認
- adminとuserの役割の付与・削除ボタンをクリックして正しく反映されるか確認
## 考慮してほしい事
- 特になし
## 確認してほしい事
- 役割の付与・削除のテーブルは管理者のみが表示される機能なので、admin(管理者)とuser(一般ユーザー)でログインして正しく反映されているか確認をお願いします