### PR TITLE
#10ユーザーの削除機能(2024.1.22)

### DIFF
--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -115,4 +115,14 @@ class ProfileController extends Controller
 
         return Redirect::route('profile.adedit',compact('user'))->with('status','profile-updated');
     }
+
+    public function addestroy(User $user) {
+        if($user->avatar!=='user_default.jpg') {
+            $oldavatar='public/avatar/'.$user->avatar;
+            Storage::delete($oldavatar);
+        }
+        $user->roles()->detach();
+        $user->delete();
+        return back()->with('message', 'ユーザーを削除しました');
+    }
 }

--- a/resources/views/post/index.blade.php
+++ b/resources/views/post/index.blade.php
@@ -27,7 +27,7 @@
     <hr class="w-full">
     <p class="mt-4 text-gray-600 py-4">{{Str::limit($post->body,100,'...') }}</p>
     <div class="text-sm font-semibold flex flex-row-reverse">
-      <p>{{ $post->user->name }} • {{ $post->created_at->diffForHumans() }}</p>
+      <p>{{ $post->user->name??'削除されたユーザー' }} • {{ $post->created_at->diffForHumans() }}</p>
      </div>
      {{-- 追加部分 --}}
      <hr class="w-full mb-2">

--- a/resources/views/post/mycomment.blade.php
+++ b/resources/views/post/mycomment.blade.php
@@ -34,7 +34,7 @@
    <hr class="w-full">
    <p class="mt-4 text-gray-600 py-4">{{Str::limit($post->body,100,'...') }}</p>
     <div class="text-sm font-semibold flex flex-row-reverse">
-     <p>{{ $post->user->name }} • {{ $post->created_at->diffForHumans() }}</p>
+     <p>{{ $post->user->name??'削除されたユーザー' }} • {{ $post->created_at->diffForHumans() }}</p>
     </div>
      {{-- 追加部分 --}}
      <hr class="w-full mb-2">

--- a/resources/views/post/mypost.blade.php
+++ b/resources/views/post/mypost.blade.php
@@ -31,7 +31,7 @@
        <hr class="w-full">
         <p class="mt-4 text-gray-600 py-4">{{Str::limit($post->body,100,'...') }}</p>
         <div class="text-sm font-semibold flex flex-row-reverse">
-         <p>{{ $post->user->name }} • {{ $post->created_at->diffForHumans() }}</p>
+         <p>{{ $post->user->name??'削除されたユーザー' }} • {{ $post->created_at->diffForHumans() }}</p>
         </div>
          {{-- 追加部分 --}}
          <hr class="w-full mb-2">

--- a/resources/views/post/show.blade.php
+++ b/resources/views/post/show.blade.php
@@ -50,7 +50,7 @@
       <img src="{{ asset('storage/images/'.$post->image)}}" alt="画像" class="mx-auto" style="height:300px;">
      @endif
      <div class="text-sm font-semibold flex flex-row-reverse">
-      <p>{{ $post->user->name }}・{{ $post->created_at->diffForHumans() }}</p> {{--コメントが作成された日時を示すカラム(xx分前など)--}}
+      <p>{{ $post->user->name??'削除されたユーザー' }}・{{ $post->created_at->diffForHumans() }}</p> {{--コメントが作成された日時を示すカラム(xx分前など)--}}
      </div>
     </div>
      {{-- コメント表示部分 --}}
@@ -59,7 +59,7 @@
       {{$comment->body}}
       <div class="text-sm font-semibold flex flex-row-reverse">
         {{-- クラスを変更 --}}
-        <p class="float-left pt-4"> {{ $comment->user->name }} • {{$comment->created_at->diffForHumans()}}</p>
+        <p class="float-left pt-4"> {{ $comment->user->name??'削除されたユーザー' }} • {{$comment->created_at->diffForHumans()}}</p>
         {{-- アバター追加 --}}
         <span class="rounded-full w-12 h-12">
          <img src="{{asset('storage/avatar/'.($comment->user->avatar??'user_default.jpg'))}}">

--- a/resources/views/profile/edit.blade.php
+++ b/resources/views/profile/edit.blade.php
@@ -12,7 +12,7 @@
                     @include('profile.partials.update-profile-information-form')
                 </div>
             </div>
-            {{-- 追加部分 --}}
+            {{-- 追加部分 役割の付与・削除テーブル(管理者のみ操作可)--}}
             @if(isset($admin))
             <div class="p-4 sm:p-8 bg-white shadow sm:rounded-lg">
                 <div class="max-w-xl">
@@ -20,17 +20,20 @@
                 </div>
             </div>
             @endif
+            {{-- パスワード変更(管理者変更不可) --}}
+            @if(!isset($admin))
             <div class="p-4 sm:p-8 bg-white shadow sm:rounded-lg">
                 <div class="max-w-xl">
                     @include('profile.partials.update-password-form')
                 </div>
             </div>
-
-            <div class="p-4 sm:p-8 bg-white shadow sm:rounded-lg">
+            @endif
+            {{-- ユーザーがアカウント削除する(できないようにコメントアウト) --}}
+            {{-- <div class="p-4 sm:p-8 bg-white shadow sm:rounded-lg">
                 <div class="max-w-xl">
                     @include('profile.partials.delete-user-form')
                 </div>
-            </div>
+            </div> --}}
         </div>
     </div>
 </x-app-layout>

--- a/resources/views/profile/index.blade.php
+++ b/resources/views/profile/index.blade.php
@@ -15,6 +15,7 @@
                     <th class="p-3 text-left text-white">Email</th>
                     <th class="p-3 text-left text-white">アバター</th>
                     <th class="p-3 text-left text-white">編集</th>
+                    <th class="p-3 text-left text-white">削除</th>
                 </tr>
                 @foreach($users as $user)
                 <tr class="bg-white">
@@ -30,6 +31,16 @@
                      <a href="{{route('profile.adedit',$user)}}">
                       <x-primary-button class="bg-teal-700">編集</x-primary-button>
                      </a>
+                    </td>
+                    {{-- 削除ボタンの追加 --}}
+                    <td class="border-gray-light border hover:bg-gray-100 p-3">
+                     <form method="post" action="{{route('profile.addestroy', $user)}}">
+                      @csrf
+                      @method('delete')
+                       <x-primary-button class="bg-red-700" onClick="return confirm('本当に削除しますか？');">
+                        削除
+                       </x-primary-button>
+                     </form>
                     </td>
                 </tr>
                 @endforeach

--- a/routes/web.php
+++ b/routes/web.php
@@ -48,11 +48,12 @@ Route::middleware('verified')->group(function () {
     Route::post('post/comment/store',[CommentController::class,'store'])->name('comment.store');
     Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');
     Route::patch('/profile', [ProfileController::class, 'update'])->name('profile.update');
-    Route::delete('/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');
+    // Route::delete('/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');
     //管理者のみ閲覧可能にする
     Route::middleware(['can:admin'])->group(function(){
         Route::get('/profile/index',[ProfileController::class,'index'])->name('profile.index');
         Route::get('/profile/adedit/{user}',[ProfileController::class,'adedit'])->name('profile.adedit');
+        Route::delete('profile/{user}', [ProfileController::class, 'addestroy'])->name('profile.addestroy');
         Route::patch('/profile/adupdate/{user}',[ProfileController::class,'adupdate'])->name('profile.adupdate');
         Route::patch('roles/{user}/attach',[RoleController::class,'attach'])->name('role.attach'); //ユーザー役割の付与
         Route::patch('roles/{user}/detach',[RokeController::class,'detach'])->name('role.detach'); //ユーザー役割の剥奪


### PR DESCRIPTION
## issue
- Close #10
## 概要
- ユーザーの削除機能
## 動作確認手順
 - 管理者(admin)でログインしユーザー一覧のページに移動
- 任意のユーザーを削除ボタンを押して削除テストを行う
- 削除したユーザーの投稿およびコメントの名前が｢削除されたユーザー｣になっている
## 考慮してほしい事
- 管理者(admin)と一般ユーザーそれぞれでログインして動作確認が必要です  
## 確認してほしい事
- 任意のユーザーの削除が正しく行えるか
- 削除したユーザーの投稿のユーザー名が変わり｢削除されたユーザー｣になっているか
